### PR TITLE
Add use of staked storage provider roles to storage subsystem.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,7 @@ impl storage::data_directory::Trait for Runtime {
     type Event = Event;
     type ContentId = ContentId;
     type Members = Members;
+    type Roles = Actors;
     type IsActiveDataObjectType = DataObjectTypeRegistry;
 }
 
@@ -265,6 +266,7 @@ impl storage::data_object_storage_registry::Trait for Runtime {
     type Event = Event;
     type DataObjectStorageRelationshipId = u64;
     type Members = Members;
+    type Roles = Actors;
     type ContentIdExists = DataDirectory;
 }
 

--- a/src/roles/actors.rs
+++ b/src/roles/actors.rs
@@ -197,12 +197,7 @@ impl<T: Trait> Roles<T> for Module<T> {
     }
 
     fn account_has_role(account_id: &T::AccountId, role: Role) -> bool {
-        let res = Self::actor_by_account_id(account_id);
-        if res.is_none() {
-            return false;
-        }
-        let actor = res.unwrap();
-        actor.role == role
+        Self::actor_by_account_id(account_id).map_or(false, |actor| actor.role == role)
     }
 
     fn random_account_for_role(role: Role) -> Result<T::AccountId, &'static str> {

--- a/src/roles/actors.rs
+++ b/src/roles/actors.rs
@@ -12,6 +12,8 @@ use system::{self, ensure_signed};
 
 use crate::traits::{Members, Roles};
 
+static MSG_NO_ACTOR_FOR_ROLE: &str = "For the specified role, no actor is currently staked.";
+
 #[derive(Encode, Decode, Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Role {
     Storage,
@@ -192,6 +194,32 @@ impl<T: Trait> Module<T> {
 impl<T: Trait> Roles<T> for Module<T> {
     fn is_role_account(account_id: &T::AccountId) -> bool {
         <ActorByAccountId<T>>::exists(account_id) || <Bondage<T>>::exists(account_id)
+    }
+
+    fn account_has_role(account_id: &T::AccountId, role: Role) -> bool {
+        let res = Self::actor_by_account_id(account_id);
+        if res.is_none() {
+            return false;
+        }
+        let actor = res.unwrap();
+        actor.role == role && <Bondage<T>>::exists(account_id)
+    }
+
+    fn random_account_for_role(role: Role) -> Result<T::AccountId, &'static str> {
+        let ids: Vec<T::AccountId> = Self::actor_account_ids()
+            .into_iter()
+            .filter(|actor_id| Self::account_has_role(actor_id, role))
+            .collect();
+        if 0 == ids.len() {
+            return Err(MSG_NO_ACTOR_FOR_ROLE);
+        }
+        let seed = <system::Module<T>>::random_seed();
+        let mut rand: u64 = 0;
+        for offset in 0..8 {
+            rand += (seed.as_ref()[offset] as u64) << offset;
+        }
+        let idx = (rand as usize) % ids.len();
+        return Ok(ids[idx].clone());
     }
 }
 

--- a/src/roles/actors.rs
+++ b/src/roles/actors.rs
@@ -202,14 +202,11 @@ impl<T: Trait> Roles<T> for Module<T> {
             return false;
         }
         let actor = res.unwrap();
-        actor.role == role && <Bondage<T>>::exists(account_id)
+        actor.role == role
     }
 
     fn random_account_for_role(role: Role) -> Result<T::AccountId, &'static str> {
-        let ids: Vec<T::AccountId> = Self::actor_account_ids()
-            .into_iter()
-            .filter(|actor_id| Self::account_has_role(actor_id, role))
-            .collect();
+        let ids = Self::account_ids_by_role(role);
         if 0 == ids.len() {
             return Err(MSG_NO_ACTOR_FOR_ROLE);
         }

--- a/src/storage/data_directory.rs
+++ b/src/storage/data_directory.rs
@@ -1,7 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use crate::roles::actors;
 use crate::storage::data_object_type_registry::Trait as DOTRTrait;
-use crate::traits::{ContentIdExists, IsActiveDataObjectType, Members};
+use crate::traits::{ContentIdExists, IsActiveDataObjectType, Members, Roles};
 use parity_codec::Codec;
 use parity_codec_derive::{Decode, Encode};
 use primitives::Ed25519AuthorityId;
@@ -27,6 +28,7 @@ pub trait Trait: timestamp::Trait + system::Trait + DOTRTrait + MaybeDebug {
         + PartialEq;
 
     type Members: Members<Self>;
+    type Roles: Roles<Self>;
     type IsActiveDataObjectType: IsActiveDataObjectType<Self>;
 }
 
@@ -120,9 +122,7 @@ decl_module! {
 
             // The liaison is something we need to take from staked roles. The idea
             // is to select the liaison, for now randomly.
-            // FIXME without that module, we're currently hardcoding it, to the
-            // origin, which is wrong on many levels.
-            let liaison = who.clone();
+            let liaison = T::Roles::random_account_for_role(actors::Role::Storage)?;
 
             // Let's create the entry then
             let new_id = Self::next_content_id();
@@ -209,9 +209,10 @@ mod tests {
                 _ => (0u64, 0xdeadbeefu64), // invalid value, unlikely to match
             };
             assert_ne!(liaison, 0xdeadbeefu64);
+            assert_eq!(liaison, TEST_MOCK_LIAISON);
 
             // Accepting content should not work with some random origin
-            let res = TestDataDirectory::accept_content(Origin::signed(42), content_id);
+            let res = TestDataDirectory::accept_content(Origin::signed(1), content_id);
             assert!(res.is_err());
 
             // However, with the liaison as origin it should.
@@ -235,9 +236,10 @@ mod tests {
                 _ => (0u64, 0xdeadbeefu64), // invalid value, unlikely to match
             };
             assert_ne!(liaison, 0xdeadbeefu64);
+            assert_eq!(liaison, TEST_MOCK_LIAISON);
 
             // Rejecting content should not work with some random origin
-            let res = TestDataDirectory::reject_content(Origin::signed(42), content_id);
+            let res = TestDataDirectory::reject_content(Origin::signed(1), content_id);
             assert!(res.is_err());
 
             // However, with the liaison as origin it should.

--- a/src/storage/data_object_storage_registry.rs
+++ b/src/storage/data_object_storage_registry.rs
@@ -1,7 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use crate::roles::actors;
 use crate::storage::data_directory::Trait as DDTrait;
-use crate::traits::{ContentHasStorage, ContentIdExists, Members};
+use crate::traits::{ContentHasStorage, ContentIdExists, Members, Roles};
 use parity_codec::Codec;
 use parity_codec_derive::{Decode, Encode};
 use rstd::prelude::*;
@@ -26,11 +27,14 @@ pub trait Trait: timestamp::Trait + system::Trait + DDTrait + MaybeDebug {
         + PartialEq;
 
     type Members: Members<Self>;
+    type Roles: Roles<Self>;
     type ContentIdExists: ContentIdExists<Self>;
 }
 
 static MSG_CID_NOT_FOUND: &str = "Content with this ID not found.";
 static MSG_DOSR_NOT_FOUND: &str = "No data object storage relationship found for this ID.";
+static MSG_ONLY_STORAGE_PROVIDER_MAY_CREATE_DOSR: &str =
+    "Only storage providers can create data object storage relationships.";
 static MSG_ONLY_STORAGE_PROVIDER_MAY_CLAIM_READY: &str =
     "Only the storage provider in a DOSR can decide whether they're ready.";
 
@@ -104,10 +108,9 @@ decl_module! {
         pub fn add_relationship(origin, cid: T::ContentId) {
             // Origin has to be a storage provider
             let who = ensure_signed(origin)?;
-            // TODO check for being staked as a storage provider
-            // if !T::Members::is_active_member(&who) {
-            //     return Err(MSG_CREATOR_MUST_BE_MEMBER);
-            // }
+
+            // Check that the origin is a storage provider
+            ensure!(<T as Trait>::Roles::account_has_role(&who, actors::Role::Storage), MSG_ONLY_STORAGE_PROVIDER_MAY_CREATE_DOSR);
 
             // Content ID must exist
             ensure!(T::ContentIdExists::has_content(&cid), MSG_CID_NOT_FOUND);
@@ -190,8 +193,11 @@ mod tests {
     #[test]
     fn test_add_relationship() {
         with_default_mock_builder(|| {
-            // The content needs to exist - in our mock, that's with the content ID 42
-            let res = TestDataObjectStorageRegistry::add_relationship(Origin::signed(1), 42);
+            // The content needs to exist - in our mock, that's with the content ID TEST_MOCK_EXISTING_CID
+            let res = TestDataObjectStorageRegistry::add_relationship(
+                Origin::signed(1),
+                TEST_MOCK_EXISTING_CID,
+            );
             assert!(res.is_ok());
         });
     }
@@ -208,7 +214,10 @@ mod tests {
     fn test_toggle_ready() {
         with_default_mock_builder(|| {
             // Create a DOSR
-            let res = TestDataObjectStorageRegistry::add_relationship(Origin::signed(1), 42);
+            let res = TestDataObjectStorageRegistry::add_relationship(
+                Origin::signed(1),
+                TEST_MOCK_EXISTING_CID,
+            );
             assert!(res.is_ok());
 
             // Grab DOSR ID from event

--- a/src/storage/data_object_storage_registry.rs
+++ b/src/storage/data_object_storage_registry.rs
@@ -195,7 +195,7 @@ mod tests {
         with_default_mock_builder(|| {
             // The content needs to exist - in our mock, that's with the content ID TEST_MOCK_EXISTING_CID
             let res = TestDataObjectStorageRegistry::add_relationship(
-                Origin::signed(1),
+                Origin::signed(TEST_MOCK_LIAISON),
                 TEST_MOCK_EXISTING_CID,
             );
             assert!(res.is_ok());
@@ -215,7 +215,7 @@ mod tests {
         with_default_mock_builder(|| {
             // Create a DOSR
             let res = TestDataObjectStorageRegistry::add_relationship(
-                Origin::signed(1),
+                Origin::signed(TEST_MOCK_LIAISON),
                 TEST_MOCK_EXISTING_CID,
             );
             assert!(res.is_ok());
@@ -240,14 +240,16 @@ mod tests {
 
             // Toggling with the wrong ID should fail.
             let res = TestDataObjectStorageRegistry::set_relationship_ready(
-                Origin::signed(1),
+                Origin::signed(TEST_MOCK_LIAISON),
                 dosr_id + 1,
             );
             assert!(res.is_err());
 
             // Toggling with the correct ID and origin should succeed
-            let res =
-                TestDataObjectStorageRegistry::set_relationship_ready(Origin::signed(1), dosr_id);
+            let res = TestDataObjectStorageRegistry::set_relationship_ready(
+                Origin::signed(TEST_MOCK_LIAISON),
+                dosr_id,
+            );
             assert!(res.is_ok());
             assert_eq!(System::events().last().unwrap().event,
                 MetaEvent::data_object_storage_registry(data_object_storage_registry::RawEvent::DataObjectStorageRelationshipReadyUpdated(

--- a/src/storage/mock.rs
+++ b/src/storage/mock.rs
@@ -65,10 +65,10 @@ impl traits::Roles<Test> for MockRoles {
     }
 
     fn account_has_role(
-        _account_id: &<Test as system::Trait>::AccountId,
+        account_id: &<Test as system::Trait>::AccountId,
         _role: actors::Role,
     ) -> bool {
-        false
+        *account_id == TEST_MOCK_LIAISON
     }
 
     fn random_account_for_role(

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use crate::roles::actors;
 use crate::storage::{data_directory, data_object_storage_registry, data_object_type_registry};
 use parity_codec::Codec;
 use runtime_primitives::traits::{As, MaybeSerializeDebug, Member, SimpleArithmetic};
@@ -42,11 +43,24 @@ impl<T: system::Trait> Members<T> for () {
 // Roles
 pub trait Roles<T: system::Trait> {
     fn is_role_account(account_id: &T::AccountId) -> bool;
+
+    fn account_has_role(account_id: &T::AccountId, role: actors::Role) -> bool;
+
+    // If available, return a random account ID for the given role.
+    fn random_account_for_role(role: actors::Role) -> Result<T::AccountId, &'static str>;
 }
 
 impl<T: system::Trait> Roles<T> for () {
     fn is_role_account(_who: &T::AccountId) -> bool {
         false
+    }
+
+    fn account_has_role(_account_id: &T::AccountId, _role: actors::Role) -> bool {
+        false
+    }
+
+    fn random_account_for_role(_role: actors::Role) -> Result<T::AccountId, &'static str> {
+        Err("not implemented")
     }
 }
 


### PR DESCRIPTION
Implements #11 

@mnaamani There's a problem here in that some tests panic. I think I may not be initializing the actor storage with test data, but it's hard for me to figure out what I should do. Do you have an insight here?