### PR TITLE
Allow optional channel fields to have an empty vector as a value

### DIFF
--- a/src/content_working_group/lib.rs
+++ b/src/content_working_group/lib.rs
@@ -1962,33 +1962,50 @@ impl<T: Trait> Module<T> {
         Ok(())
     }
 
-    fn ensure_channel_title_is_valid(title: &Vec<u8>) -> dispatch::Result {
+    
+    fn ensure_channel_title_is_valid(text: &Vec<u8>) -> dispatch::Result {
+        if text.is_empty() {
+            return Ok(())
+        }
+
         ChannelTitleConstraint::get().ensure_valid(
-            title.len(),
+            text.len(),
             MSG_CHANNEL_TITLE_TOO_SHORT,
             MSG_CHANNEL_TITLE_TOO_LONG,
         )
     }
 
-    fn ensure_channel_description_is_valid(description: &Vec<u8>) -> dispatch::Result {
+    fn ensure_channel_description_is_valid(text: &Vec<u8>) -> dispatch::Result {
+        if text.is_empty() {
+            return Ok(())
+        }
+
         ChannelDescriptionConstraint::get().ensure_valid(
-            description.len(),
+            text.len(),
             MSG_CHANNEL_DESCRIPTION_TOO_SHORT,
             MSG_CHANNEL_DESCRIPTION_TOO_LONG,
         )
     }
 
-    fn ensure_channel_avatar_is_valid(avatar: &Vec<u8>) -> dispatch::Result {
+    fn ensure_channel_avatar_is_valid(text: &Vec<u8>) -> dispatch::Result {
+        if text.is_empty() {
+            return Ok(())
+        }
+
         ChannelAvatarConstraint::get().ensure_valid(
-            avatar.len(),
+            text.len(),
             MSG_CHANNEL_AVATAR_TOO_SHORT,
             MSG_CHANNEL_AVATAR_TOO_LONG,
         )
     }
 
-    fn ensure_channel_banner_is_valid(banner: &Vec<u8>) -> dispatch::Result {
+    fn ensure_channel_banner_is_valid(text: &Vec<u8>) -> dispatch::Result {
+        if text.is_empty() {
+            return Ok(())
+        }
+        
         ChannelBannerConstraint::get().ensure_valid(
-            banner.len(),
+            text.len(),
             MSG_CHANNEL_BANNER_TOO_SHORT,
             MSG_CHANNEL_BANNER_TOO_LONG,
         )

--- a/src/content_working_group/lib.rs
+++ b/src/content_working_group/lib.rs
@@ -1181,17 +1181,11 @@ decl_module! {
             curation_actor: CurationActor<CuratorId<T>>,
             channel_id: ChannelId<T>,
             new_verified: Option<bool>,
-            new_description: Option<Vec<u8>>,
             new_curation_status: Option<ChannelCurationStatus>
         ) {
 
             // Ensure curation actor signed
             Self::ensure_curation_actor_signed(origin, &curation_actor)?;
-
-            // If set, ensure description is acceptable length
-            if let Some(ref description) = new_description {
-                Self::ensure_channel_description_is_valid(description)?;
-            }
 
             //
             // == MUTATION SAFE ==
@@ -1202,7 +1196,7 @@ decl_module! {
                 &new_verified,
                 &None, // handle
                 &None, // title
-                &new_description,
+                &None, // description,
                 &None, // avatar
                 &None, // banner
                 &None, // publishing_status


### PR DESCRIPTION
If such optional channel fields as title, description, avatar or banner have an empty `Vec<u8>` as a value, then it means that value is not set for this field.