### PR TITLE
btreeset workaround

### DIFF
--- a/src/content_working_group/lib.rs
+++ b/src/content_working_group/lib.rs
@@ -86,6 +86,9 @@ pub type StakeId<T> = <T as stake::Trait>::StakeId;
 /// Type of permissions module prinicipal identifiers
 pub type PrincipalId<T> = <T as versioned_store_permissions::Trait>::PrincipalId;
 
+// Workaround for BTreeSet type
+pub type CuratorApplicationIdSet<T> = BTreeSet<CuratorApplicationId<T>>;
+
 /*
  * MOVE ALL OF THESE OUT TO COMMON LATER
  */
@@ -1421,7 +1424,7 @@ decl_module! {
         pub fn fill_curator_opening(
             origin,
             curator_opening_id: CuratorOpeningId<T>,
-            successful_curator_application_ids: BTreeSet<CuratorApplicationId<T>>
+            successful_curator_application_ids: CuratorApplicationIdSet<T>, 
         ) {
             // Ensure lead is set and is origin signer
             let (lead_id, _lead) = Self::ensure_origin_is_set_lead(origin)?;


### PR DESCRIPTION
This is a workaround for a required BTreeSet extrinsic call in the curators working group defined in the runtime. This requires https://github.com/Joystream/apps/pull/262 for the Pioneer integration.