### PR TITLE
Merge versioned store & versioned-permissions core logic

### DIFF
--- a/runtime-modules/versioned-store-permissions/src/errors.rs
+++ b/runtime-modules/versioned-store-permissions/src/errors.rs
@@ -1,0 +1,38 @@
+// Validation errors
+// --------------------------------------
+
+pub const ERROR_PROPERTY_NAME_TOO_SHORT: &str = "Property name is too short";
+pub const ERROR_PROPERTY_NAME_TOO_LONG: &str = "Property name is too long";
+pub const ERROR_PROPERTY_DESCRIPTION_TOO_SHORT: &str = "Property description is too long";
+pub const ERROR_PROPERTY_DESCRIPTION_TOO_LONG: &str = "Property description is too long";
+
+pub const ERROR_CLASS_NAME_TOO_SHORT: &str = "Class name is too short";
+pub const ERROR_CLASS_NAME_TOO_LONG: &str = "Class name is too long";
+pub const ERROR_CLASS_DESCRIPTION_TOO_SHORT: &str = "Class description is too long";
+pub const ERROR_CLASS_DESCRIPTION_TOO_LONG: &str = "Class description is too long";
+
+// Main logic errors
+// --------------------------------------
+
+pub const ERROR_CLASS_NOT_FOUND: &str = "Class was not found by id";
+pub const ERROR_UNKNOWN_CLASS_SCHEMA_ID: &str = "Unknown class schema id";
+pub const ERROR_CLASS_SCHEMA_REFERS_UNKNOWN_PROP_INDEX: &str =
+    "New class schema refers to an unknown property index";
+pub const ERROR_CLASS_SCHEMA_REFERS_UNKNOWN_INTERNAL_ID: &str =
+    "New class schema refers to an unknown internal class id";
+pub const ERROR_NO_PROPS_IN_CLASS_SCHEMA: &str =
+    "Cannot add a class schema with an empty list of properties";
+pub const ERROR_ENTITY_NOT_FOUND: &str = "Entity was not found by id";
+// pub const ERROR_ENTITY_ALREADY_DELETED: &str = "Entity is already deleted";
+pub const ERROR_SCHEMA_ALREADY_ADDED_TO_ENTITY: &str =
+    "Cannot add a schema that is already added to this entity";
+pub const ERROR_PROP_VALUE_DONT_MATCH_TYPE: &str =
+    "Some of the provided property values don't match the expected property type";
+pub const ERROR_PROP_NAME_NOT_UNIQUE_IN_CLASS: &str = "Property name is not unique within its class";
+pub const ERROR_MISSING_REQUIRED_PROP: &str =
+    "Some required property was not found when adding schema support to entity";
+pub const ERROR_UNKNOWN_ENTITY_PROP_ID: &str = "Some of the provided property ids cannot be found on the current list of propery values of this entity";
+pub const ERROR_TEXT_PROP_IS_TOO_LONG: &str = "Text propery is too long";
+pub const ERROR_VEC_PROP_IS_TOO_LONG: &str = "Vector propery is too long";
+pub const ERROR_INTERNAL_RPOP_DOES_NOT_MATCH_ITS_CLASS: &str =
+    "Internal property does not match its class";

--- a/runtime-modules/versioned-store-permissions/src/mock.rs
+++ b/runtime-modules/versioned-store-permissions/src/mock.rs
@@ -17,7 +17,7 @@ impl_outer_origin! {
 }
 
 // Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct Runtime;
 parameter_types! {
     pub const BlockHashCount: u64 = 250;
@@ -56,6 +56,7 @@ impl versioned_store::Trait for Runtime {
 }
 
 impl Trait for Runtime {
+    type Event = ();
     type Credential = u64;
     type CredentialChecker = MockCredentialChecker;
     type CreateClassPermissionsChecker = MockCreateClassPermissionsChecker;

--- a/runtime-modules/versioned-store-permissions/src/operations.rs
+++ b/runtime-modules/versioned-store-permissions/src/operations.rs
@@ -1,7 +1,7 @@
 use codec::{Decode, Encode};
 use rstd::collections::btree_map::BTreeMap;
 use rstd::prelude::*;
-use versioned_store::{ClassId, ClassPropertyValue, EntityId, PropertyValue};
+use crate::{ClassId, ClassPropertyValue, EntityId, PropertyValue};
 
 #[derive(Encode, Decode, Eq, PartialEq, Clone, Debug)]
 pub enum ParametrizedPropertyValue {

--- a/runtime-modules/versioned-store-permissions/src/permissions.rs
+++ b/runtime-modules/versioned-store-permissions/src/permissions.rs
@@ -44,6 +44,7 @@ where
     Credential: Ord + Clone,
     PropertyIndex: Ord,
 {
+
     /// Returns Ok if access_level is root origin or credential is in admins set, Err otherwise
     pub fn is_admin(
         class_permissions: &Self,


### PR DESCRIPTION
Part of https://github.com/Joystream/joystream/issues/179
- `Class` and `ClassPermission`, only have one instance per class, and only one map
- `Entity` and `EntityPermission`, only have one instance per entity, and only one map.